### PR TITLE
Add support to quartus IP files

### DIFF
--- a/hdlmake/srcfile.py
+++ b/hdlmake/srcfile.py
@@ -264,6 +264,11 @@ class WBGenFile(File):
 
 # INTEL/ALTERA FILES
 
+class IPFile(File):
+    """This is the class providing the Altera Quartus IP file"""
+    pass
+
+
 class QIPFile(File):
     """This is the class providing the Altera Quartus IP file"""
     pass
@@ -311,6 +316,7 @@ class SignalTapFile(File):
 
 ALTERA_FILE_DICT = {
     'stp': SignalTapFile,
+    'ip': IPFile,
     'qip': QIPFile,
     'qsys': QSYSFile,
     'dpf': DPFFile,

--- a/hdlmake/tools/quartus.py
+++ b/hdlmake/tools/quartus.py
@@ -32,8 +32,9 @@ from .make_syn import ToolSyn
 from hdlmake.util import path as path_mod
 from hdlmake.util import shell
 from hdlmake.srcfile import (VHDLFile, VerilogFile, SVFile, DPFFile,
-                             SignalTapFile, SDCFile, QIPFile, QSYSFile,
-                             QSFFile, BSFFile, BDFFile, TDFFile, GDFFile)
+                             SignalTapFile, SDCFile, IPFile, QIPFile,
+                             QSYSFile, QSFFile, BSFFile, BDFFile, TDFFile,
+                             GDFFile)
 
 
 class ToolQuartus(ToolSyn):
@@ -54,6 +55,7 @@ class ToolQuartus(ToolSyn):
     SUPPORTED_FILES = {
         SignalTapFile: _QUARTUS_SOURCE.format('SIGNALTAP_FILE'),
         SDCFile: _QUARTUS_SOURCE.format('SDC_FILE'),
+        IPFile: _QUARTUS_SOURCE.format('IP_FILE'),
         QIPFile: _QUARTUS_SOURCE.format('QIP_FILE'),
         QSYSFile: _QUARTUS_SOURCE.format('QSYS_FILE'),
         DPFFile: _QUARTUS_SOURCE.format('MISC_FILE'),


### PR DESCRIPTION
Hello, 
My projects in Quartus consist of some .ip files. Those files representing IP cores added through Megawizard. There was no support for those files in hdlmake so I've added it. Would You like to Pull?